### PR TITLE
Set 'refresh_interval' to 1 second to improve Ember app user experience

### DIFF
--- a/pass-indexer-core/src/main/resources/esindex.json
+++ b/pass-indexer-core/src/main/resources/esindex.json
@@ -1,7 +1,7 @@
 {
   "settings": {
     "index" : {
-      "refresh_interval" : "10s"
+      "refresh_interval" : "1s"
     },
     "analysis": {
       "char_filter" : {


### PR DESCRIPTION
This should help mitigate an issue with the user experience:

After the user finalizes and submits a Submission in PASS, several objects are saved to Fedora, which will kick off the indexer. Previously, it would take as much as 10 seconds for these objects to be indexed and visible in the search service. It was easy for a user to click the Submit button, then navigate to the Submissions table in PASS to view the submission, however, due to the time lag of the indexer, the submission might or might not be visible. Lowering the `refresh_interval` to 1 second should be reasonable so that a user will basically always see their new submission in the Submissions table.

https://github.com/OA-PASS/pass-ember/issues/492

### Note about `refresh_interval`

The original `10s` interval was set to ease the initial data import. However, setting this interval to a lower time is better for user facing apps, as described above. The daily grant updates/imports seem to be limited to a relatively small number of objects.

If we need to do another bulk operation in the future and the 1 second refresh interval puts too much stress on the indexer, the interval can be changed dynamically. See the ES docs: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html

