### PR TITLE
[DO NOT MERGE] Upgrade indexer to use oapass/fcrepo:4.7.5-2.3-SNAPSHOT.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-8
+    image: oapass/fcrepo:4.7.5-2.3-SNAPSHOT
     container_name: fcrepo
     env_file: .env
     environment:

--- a/pass-indexer-cli/pom.xml
+++ b/pass-indexer-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-indexer</artifactId>
-    <version>0.0.12-SNAPSHOT</version>
+    <version>0.0.13-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-indexer-cli</artifactId>

--- a/pass-indexer-core/pom.xml
+++ b/pass-indexer-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-indexer</artifactId>
-    <version>0.0.12-SNAPSHOT</version>
+    <version>0.0.13-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-indexer-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-indexer</artifactId>
-  <version>0.0.12-SNAPSHOT</version>
+  <version>0.0.13-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>pass indexer</name>


### PR DESCRIPTION
Upgrade indexer to execute ITs against oapass/fcrepo:4.7.5-2.3-SNAPSHOT.  

Bump indexer version to 0.0.13-SNAPSHOT.