### PR TITLE
Index Fedora create/modify headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ The pass-indexer keeps an [Elasticsearch](https://github.com/elastic/elasticsear
 The pass-indexer monitors a JMS queue for messages about creation, deletion, and modification of Fedora resources.
 (Fedora must be configured appropriately to setup this queue.)
 
-The Elasticsearch index is created on startup if it does not exist with a set [configuration](pass-indexer-core/src/main/resources/esindex.json).
-(That configuration default can be changed.)
-If the index does exist, the configuration is retrieved from the index. In either case the mapping must match the documents which will be indexed.
-The Elasticsearch document is the compact JSON-LD representation of that resource without server triples. If a key on the document is not present
-in the mapping for the index, then the key is removed from the document and a warning is logged.
-
-When there is a message about a resource of a type being monitored, the indexer either creates a corresponding document in Elasticsearch 
+The Elasticsearch index is created on startup if it does not exist. (The configuration of a new index can be specified.)
+If the index does exist, the configuration is retrieved from the index. In either case the index mapping must be consistent with incoming Fedora objects.
+The Elasticsearch document is the compact JSON-LD representation of that resource without server triples.
+If a key on the document is not present in the mapping for the index, then the key is removed from the document and a warning is logged.
+Object values are not supported and are removed. If there are X-CREATED and X-MODIFIED headers present, then they are put into fcrepo_created and fcrepo_modified
+fields respectively. When there is a message about a resource of a type being monitored, the indexer either creates a corresponding document in Elasticsearch 
 from the Fedora resource, updates such a document, or deletes the document.  Only messages about a resource of a type which matches a
 configured prefix, PI_TYPE_PREFIX, are handled. The id of the Elasticsearch document is the safe URL base64 encoding of resource path. This lets both the document be created and updated with the same PUT.
 
@@ -88,3 +87,11 @@ The PI_FEDORA_USER and PI_FEDORA_PASS are the credentials used to connect to Fed
 The PI_FEDORA_JMS_USER and PI_FEDORA_JMS_PASSWORD are credentials used to connect to the activemq broker, if it is secured.
 
 The PI_ES_INDEX is the index where Fedora documents are sent. PI_ES_CONFIG is the configuration used to create an index if it does not exist. It must be set even if not used. It's value may be a file path or a classpath resource or a URL. 
+
+# Running Integration Tests
+
+Use `docker-compose up` to start Fedora and Elasticsearch containers.
+Then `mvn verify` will start the integration tests.
+
+The tests do not clean up Fedora or Elasticsearch so they can be inspected in case of test failures. To rerun the tests you must `docker-compose down` and then `docker volume prune`.
+

--- a/pass-indexer-cli/pom.xml
+++ b/pass-indexer-cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-indexer</artifactId>
-    <version>0.0.19-SNAPSHOT</version>
+    <version>0.0.20-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-indexer-cli</artifactId>

--- a/pass-indexer-core/pom.xml
+++ b/pass-indexer-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.dataconservancy.pass</groupId>
     <artifactId>pass-indexer</artifactId>
-    <version>0.0.19-SNAPSHOT</version>
+    <version>0.0.20-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-indexer-core</artifactId>

--- a/pass-indexer-core/src/main/java/org/dataconservancy/pass/indexer/IndexerConstants.java
+++ b/pass-indexer-core/src/main/java/org/dataconservancy/pass/indexer/IndexerConstants.java
@@ -8,6 +8,11 @@ import okhttp3.MediaType;
 public interface IndexerConstants {
     String FEDORA_ACCEPT_HEADER = "application/ld+json; profile=\"http://www.w3.org/ns/json-ld#compacted\"";
     String FEDORA_PREFER_HEADER = "return=representation; omit=\"http://fedora.info/definitions/v4/repository#ServerManaged\"";
+    String FEDORA_CREATED_HEADER = "X-CREATED";
+    String FEDORA_MODIFIED_HEADER = "X-MODIFIED";
+   
+    String CREATED_FIELD = "fcrepo_created";
+    String MODIFIED_FIELD = "fcrepo_modified";
     
     MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 }

--- a/pass-indexer-core/src/test/java/org/dataconservancy/pass/indexer/PassIndexerIT.java
+++ b/pass-indexer-core/src/test/java/org/dataconservancy/pass/indexer/PassIndexerIT.java
@@ -38,6 +38,7 @@ public class PassIndexerIT implements IndexerConstants {
 	private static final String fedora_base_uri = "http://localhost:8080/fcrepo/rest/";
 	private static final String es_uri = "http://localhost:9200/_search";
 	private static final MediaType JSON_LD = MediaType.parse("application/ld+json; charset=utf-8");
+	private static final MediaType JSON_MERGE_PATCH = MediaType.parse("application/merge-patch+json; charset=utf-8");
 	private static final int WAIT_TIME = 20 * 1000;
 
 	private static FedoraIndexerService serv;
@@ -86,11 +87,11 @@ public class PassIndexerIT implements IndexerConstants {
 	}
 
 	// Update a Fedora resource
-	private void put_fedora_resource(String uri, JSONObject content) throws Exception {
-		RequestBody body = RequestBody.create(JSON_LD, content.toString());
+	private void patch_fedora_resource(String uri, JSONObject content) throws Exception {
+		RequestBody body = RequestBody.create(JSON_MERGE_PATCH, content.toString());
 
 		Request put = new Request.Builder().url(uri).header("Authorization", fedora_cred)
-				.header("Prefer", FEDORA_PREFER_HEADER).put(body).build();
+				.header("Prefer", FEDORA_PREFER_HEADER).patch(body).build();
 
 		try (Response response = client.newCall(put).execute()) {
 			if (!response.isSuccessful()) {
@@ -248,7 +249,7 @@ public class PassIndexerIT implements IndexerConstants {
 		// Update the Fedora resource
 		user.put("displayName", "Bob");
 
-		put_fedora_resource(uri, user);
+		patch_fedora_resource(uri, user);
 		Thread.sleep(WAIT_TIME);
 
 		// Check the Es document

--- a/pass-indexer-core/src/test/resources/esindex.json
+++ b/pass-indexer-core/src/test/resources/esindex.json
@@ -46,7 +46,9 @@
       "properties": {
         "@context": {"type": "keyword", "normalizer": "fedora_uri"},
         "@id": {"type": "keyword", "normalizer": "fedora_uri"},
-        "@type": {"type": "keyword"},        
+        "fcrepo_created": {"type": "date"},
+        "fcrepo_modified": {"type": "date"},
+        "@type": {"type": "keyword"},	  
         "abstract": {"type": "text"},
         "accessUrl": {"type": "keyword", "normalizer": "fedora_uri"},
         "affiliation": {"type": "text"},

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.dataconservancy.pass</groupId>
   <artifactId>pass-indexer</artifactId>
-  <version>0.0.19-SNAPSHOT</version>
+  <version>0.0.20-SNAPSHOT</version>
 
   <packaging>pom</packaging>
   <name>pass indexer</name>


### PR DESCRIPTION
When a Fedora Object is indexed on creation or update, it is checked for headers with created and modified dates. If those headers exist, the values are added to the corresponding Elasticsearch document. See the updated README for the proposed header and field names. 

TODO:
- Agree on header and field names
- Update Elasticsearch mapping in pass-data-model
- Update fcrepo servlet filters to add headers
- Get ITs working against an updated fcrepo 
